### PR TITLE
Move progressbar tokens from foundations to component

### DIFF
--- a/src/ProgressBar/Tokens/tokens.ts
+++ b/src/ProgressBar/Tokens/tokens.ts
@@ -1,0 +1,118 @@
+import { inube } from "@inubekit/foundations";
+
+const tokens = {
+  primary: {
+    background: {
+      color: inube.palette.blue.B400,
+    },
+    animation: {
+      color: inube.palette.blue.B50,
+    },
+    border: {
+      color: inube.palette.neutral.N40,
+    },
+    track: {
+      color: inube.palette.neutral.N10,
+    },
+  },
+  success: {
+    background: {
+      color: inube.palette.green.G400,
+    },
+    animation: {
+      color: inube.palette.green.G50,
+    },
+    border: {
+      color: inube.palette.neutral.N40,
+    },
+    track: {
+      color: inube.palette.neutral.N10,
+    },
+  },
+  warning: {
+    background: {
+      color: inube.palette.yellow.Y400,
+    },
+    animation: {
+      color: inube.palette.yellow.Y50,
+    },
+    border: {
+      color: inube.palette.neutral.N40,
+    },
+    track: {
+      color: inube.palette.neutral.N10,
+    },
+  },
+  danger: {
+    background: {
+      color: inube.palette.red.R400,
+    },
+    animation: {
+      color: inube.palette.red.R50,
+    },
+    border: {
+      color: inube.palette.neutral.N40,
+    },
+    track: {
+      color: inube.palette.neutral.N10,
+    },
+  },
+  help: {
+    background: {
+      color: inube.palette.purple.P400,
+    },
+    animation: {
+      color: inube.palette.purple.P50,
+    },
+    border: {
+      color: inube.palette.neutral.N40,
+    },
+    track: {
+      color: inube.palette.neutral.N10,
+    },
+  },
+  dark: {
+    background: {
+      color: inube.palette.neutral.N900,
+    },
+    animation: {
+      color: inube.palette.neutral.N200,
+    },
+    border: {
+      color: inube.palette.neutral.N40,
+    },
+    track: {
+      color: inube.palette.neutral.N10,
+    },
+  },
+  gray: {
+    background: {
+      color: inube.palette.neutral.N50,
+    },
+    animation: {
+      color: inube.palette.neutral.N20,
+    },
+    border: {
+      color: inube.palette.neutral.N40,
+    },
+    track: {
+      color: inube.palette.neutral.N10,
+    },
+  },
+  light: {
+    background: {
+      color: inube.palette.neutral.N10,
+    },
+    animation: {
+      color: inube.palette.neutral.N0,
+    },
+    border: {
+      color: inube.palette.neutral.N40,
+    },
+    track: {
+      color: inube.palette.neutral.N50,
+    },
+  },
+};
+
+export { tokens };

--- a/src/ProgressBar/stories/styles.js
+++ b/src/ProgressBar/stories/styles.js
@@ -10,7 +10,7 @@ const StyledText = styled.p`
   margin: 0;
   padding: 0;
   text-align: start;
-  color: ${inube.text.primary.content.color.regular};
+  color: ${inube.palette.blue.B400};
 `;
 
 export { StyledText };

--- a/src/ProgressBar/styles.js
+++ b/src/ProgressBar/styles.js
@@ -1,5 +1,5 @@
 import styled, { css, keyframes } from "styled-components";
-import { inube } from "@inubekit/foundations"; 
+import { tokens } from "./Tokens/tokens";
 
 const shimmer = keyframes`
   0% {
@@ -16,7 +16,7 @@ const StyledProgressBar = styled.div`
   background-color: ${({ theme, $appearance }) => {
     return (
       theme?.progressbar?.[$appearance]?.background.color ||
-      inube.progressbar[$appearance].background.color
+      tokens[$appearance].background.color
     );
   }};
   transition: width 0.4s ease;
@@ -27,7 +27,7 @@ const StyledProgressBar = styled.div`
       position: relative;
       overflow: hidden;
       background: ${theme?.progressbar?.[$appearance]?.animation.color ||
-      inube.progressbar[$appearance].animation.color};
+      tokens[$appearance].animation.color};
 
       &::after {
         content: "";
@@ -36,9 +36,9 @@ const StyledProgressBar = styled.div`
         width: 100%;
         background: ${({ theme }) => `linear-gradient(
           90deg,
-          ${theme?.progressbar?.[$appearance]?.track.color || inube.progressbar[$appearance].track.color} 25%,
-          ${theme?.progressbar?.[$appearance]?.animation.color || inube.progressbar[$appearance].animation.color} 50%,
-          ${theme?.progressbar?.[$appearance]?.track.color || inube.progressbar[$appearance].track.color} 100%
+          ${theme?.progressbar?.[$appearance]?.track.color || tokens[$appearance].track.color} 25%,
+          ${theme?.progressbar?.[$appearance]?.animation.color || tokens[$appearance].animation.color} 50%,
+          ${theme?.progressbar?.[$appearance]?.track.color || tokens[$appearance].track.color} 100%
           
         );`};
         animation: ${shimmer} 2s linear infinite;


### PR DESCRIPTION
This PR relocates the progressbar tokens from the foundations folder to the component folder, updating all necessary imports to reflect the new structure and ensuring that components reference the correct token paths. This change enhances the organization, maintainability, and clarity of the codebase.